### PR TITLE
switch to RustCrypto traits, change API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ hmac = "0.4.*"
 [dev-dependencies]
 crypto-tests = "0.5.*"
 hex = "0.2.*"
+sha-1 = "0.4.*"
 sha2 = "0.6.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ hmac = "0.4.*"
 
 [dev-dependencies]
 crypto-tests = "0.5.*"
+hex = "0.2.*"
+sha2 = "0.6.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,9 @@ name = "hkdf"
 path = "src/hkdf.rs"
 
 [dependencies]
-rust-crypto = "0.2.36"
-rustc-serialize = "0.3.24"
+generic-array = "0.8.*"
+digest = "0.6.*"
+hmac = "0.4.*"
+
+[dev-dependencies]
+crypto-tests = "0.5.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "hkdf"
 path = "src/hkdf.rs"
 
 [dependencies]
-generic-array = "0.8.*"
+generic-array = "0.9.*"
 digest = "0.6.*"
 hmac = "0.4.*"
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,15 +1,17 @@
-extern crate rustc_serialize;
+extern crate hex;
 extern crate hkdf;
+extern crate sha2;
 
-use rustc_serialize::hex::{ToHex,FromHex};
+use sha2::Sha256;
+use hex::{ToHex,FromHex};
 use hkdf::Hkdf;
 
 fn main() {
-    let ikm = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".from_hex().unwrap();
-    let salt = "000102030405060708090a0b0c".from_hex().unwrap();
-    let info = "f0f1f2f3f4f5f6f7f8f9".from_hex().unwrap();
+    let ikm = Vec::from_hex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
+    let salt = Vec::from_hex("000102030405060708090a0b0c").unwrap();
+    let info = Vec::from_hex("f0f1f2f3f4f5f6f7f8f9").unwrap();
 
-    let mut hk = Hkdf::new("SHA-256", &ikm, &salt);
+    let mut hk = Hkdf::<Sha256>::new(&ikm, &salt);
     let okm = hk.derive(&info, 42);
 
     println!("Vector 1 PRK is {}", hk.prk.to_hex());

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -10,13 +10,12 @@ extern crate sha_1;
 extern crate sha2;
 
 use std::cmp;
-use digest::{Input, BlockInput, FixedOutput};
-use digest::Digest; // for sizetest=D::new()
+use digest::Digest;
 use generic_array::{ArrayLength, GenericArray};
 use hmac::{Hmac, Mac};
 
 pub struct Hkdf<D>
-    where D: Input + BlockInput + FixedOutput + Default,
+    where D: Digest + Default,
           D::OutputSize: ArrayLength<u8>
 {
     pub prk: GenericArray<u8, D::OutputSize>,
@@ -40,10 +39,8 @@ impl<D> Hkdf<D>
         let mut okm = Vec::<u8>::with_capacity(length);
         let mut prev = Vec::<u8>::new();
 
-        //if length > <D as FixedOutput>::OutputSize.to_usize() * 255 {
-        //if length > D::OutputSize.to_usize() * 255 {
-        let sizetest = D::new();
-        let hmac_output_bytes = sizetest.fixed_result().len();
+        use generic_array::typenum::Unsigned;
+        let hmac_output_bytes = D::OutputSize::to_usize();
         if length > hmac_output_bytes * 255 {
             panic!("Invalid number of blocks, length too large");
         }

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -84,7 +84,7 @@ mod tests {
 
     // Test Vectors from https://tools.ietf.org/html/rfc5869.
     fn tests<'a>() -> Vec<Test<'a>> {
-        vec![Test {
+        vec![Test { // Test Case 1
                  ikm: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                  salt: "000102030405060708090a0b0c",
                  info: "f0f1f2f3f4f5f6f7f8f9",
@@ -93,7 +93,7 @@ mod tests {
                  okm: "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b8\
                        87185865",
              },
-             Test {
+             Test { // Test Case 2
                  ikm: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425\
                        262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b\
                        4c4d4e4f",
@@ -109,7 +109,7 @@ mod tests {
                        827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5\
                        c1f3434f1d87",
              },
-             Test {
+             Test { // Test Case 3
                  ikm: "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                  salt: "",
                  info: "",

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -22,8 +22,8 @@ pub struct Hkdf<D>
     pub prk: GenericArray<u8, D::OutputSize>,
 }
 
-impl <D> Hkdf<D>
-    where D: Input + BlockInput + FixedOutput + Default,
+impl<D> Hkdf<D>
+    where D: Digest + Default,
           D::OutputSize: ArrayLength<u8>
 {
     pub fn new(ikm: &[u8], salt: &[u8]) -> Hkdf<D> {
@@ -55,7 +55,7 @@ impl <D> Hkdf<D>
             let c = vec![blocknum as u8];
 
             output_block.input(&prev);
-            output_block.input(&info);
+            output_block.input(info);
             output_block.input(&c);
 
             prev = output_block.result().code().to_vec();
@@ -65,7 +65,7 @@ impl <D> Hkdf<D>
             remaining -= needed;
         }
 
-        return okm;
+        okm
     }
 }
 


### PR DESCRIPTION
This moves away from rust-crypto to RustCrypto, which my rust+crypto friends tell me is the preferred approach these days. It modifies the HKDF API to instantiate the Hkdf object around a Digest trait, so instead of passing in "sha256" as a string, you `use sha2::Sha256` and then create `Hkdf::<Sha256:>>new(&ikm, &salt)`.

It also adds test vectors for SHA1.

This will change the API, so the rust-hkdf version should be bumped after landing this.

This replaces #4, for which I accidentally deleted the branch after rebasing to current master.