### PR TITLE
update dependencies: digest-0.7, hmac-0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ path = "src/hkdf.rs"
 
 [dependencies]
 generic-array = "0.9.*"
-digest = "0.6.*"
-hmac = "0.4.*"
+digest = "0.7.*"
+hmac = "0.5.*"
 
 [dev-dependencies]
 crypto-tests = "0.5.*"
 hex = "0.2.*"
-sha-1 = "0.4.*"
-sha2 = "0.6.*"
+sha-1 = "0.7.*"
+sha2 = "0.7.*"

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -26,8 +26,12 @@ impl<D> Hkdf<D>
           D::OutputSize: ArrayLength<u8>
 {
     pub fn new(ikm: &[u8], salt: &[u8]) -> Hkdf<D> {
-        // Hmac::new() is now defined to return a Result, but as far as I can
-        // tell, it can only return Ok.
+        // The hmac-0.5 MAC trait (which provides new()) is now defined to
+        // return a Result, apparently to support things like CMAC which
+        // require a specific key length. As far as I can tell, HMAC in
+        // particular can only return an Ok(), since HMAC accepts any length
+        // of bytes as its key. So we use unwrap() here, rather than exposing
+        // the error to our caller. This might change in a future version.
         let mut hmac = Hmac::<D>::new(salt).unwrap();
         hmac.input(ikm);
         let mut arr = GenericArray::default();


### PR DESCRIPTION
This involves a few internal API changes. Applications or libraries which use
hkdf will almost certainly need to depend on e.g. sha2-0.7 instead of
sha2-0.6, so when this change is released, we should bump the hkdf version
number (from the current 0.2.1 to something like 0.3.0).