### PR TITLE
Reduce heap allocation, remove unnecessary mut, derive Clone

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,8 +10,8 @@ fn main() {
     let salt = hex::decode("000102030405060708090a0b0c").unwrap();
     let info = hex::decode("f0f1f2f3f4f5f6f7f8f9").unwrap();
 
-    let hk = Hkdf::<Sha256>::new(&ikm, &salt);
-    let okm = hk.derive(&info, 42);
+    let hk = Hkdf::<Sha256>::extract(&salt, &ikm);
+    let okm = hk.expand(&info, 42);
 
     println!("Vector 1 PRK is {}", hex::encode(hk.prk));
     println!("Vector 1 OKM is {}", hex::encode(&okm));
@@ -20,4 +20,3 @@ fn main() {
     let expected = "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865";
     assert_eq!(hex::encode(&okm), expected);
 }
-

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -10,7 +10,7 @@ fn main() {
     let salt = hex::decode("000102030405060708090a0b0c").unwrap();
     let info = hex::decode("f0f1f2f3f4f5f6f7f8f9").unwrap();
 
-    let mut hk = Hkdf::<Sha256>::new(&ikm, &salt);
+    let hk = Hkdf::<Sha256>::new(&ikm, &salt);
     let okm = hk.derive(&info, 42);
 
     println!("Vector 1 PRK is {}", hex::encode(hk.prk));


### PR DESCRIPTION
This improves usability and marginally improves performance:

Before:
```
test sha256_10 ... bench:       4,176 ns/iter (+/- 88) = 2 MB/s
test sha256_1k ... bench:      68,458 ns/iter (+/- 2,005) = 14 MB/s
test sha256_8k ... bench:     520,298 ns/iter (+/- 14,572) = 15 MB/s
```

After:
```
test sha256_10 ... bench:       4,113 ns/iter (+/- 535) = 2 MB/s
test sha256_1k ... bench:      66,892 ns/iter (+/- 8,179) = 15 MB/s
test sha256_8k ... bench:     506,935 ns/iter (+/- 57,681) = 15 MB/s
```